### PR TITLE
Add a controller to render entries as actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Configure SolidusContent in an initializer:
 SolidusContent.configure do |config|
   # your configuration goes here...
 
+  # See "Registering a content provider" for detailed instructions
+  # config.content_providers[:my_provider] = ->(input) { … }
+
   # Set to `true` to register your own route, instead of using the default
   # that starts with `/c/`.
   # config.skip_default_route = true

--- a/README.md
+++ b/README.md
@@ -35,12 +35,49 @@ home = SolidusContent.create!(
 )
 ```
 
-Inside `app/views/spree/home/index.html.erb`:
+### Within an existing view
+
+Use the content inside an existing view, e.g. `app/views/spree/home/index.html.erb`:
 
 ```erb
 <% data = SolidusContent::Entry.data_for(:home, :default) %>
 
 <h1><%= data[:title] %></h1>
+```
+
+### With the default route
+
+SolidusContent will add a default route that starts with `/c/`, by adding a view
+inside `app/views/spree/solidus_content/` with the name of the entry type you'll
+be able to render your content.
+
+E.g. `app/views/spree/solidus_content/home.html.erb`:
+```erb
+<h1><%= data[:title] %></h1>
+```
+
+Then, visit `/c/home/default` or even just `/c/home` (when the content slug is 
+"default" it can be omitted).
+
+
+### With a custom route
+
+You can also define a custom route and use the SolidusContent controller to 
+render your content from a dedicated view:
+
+```rb
+# config/routes.rb
+Spree::Core::Engine.routes.draw do
+  # Will render app/views/spree/solidus_content/home.html.erb
+  root to: 'solidus_content#show', type: :home, id: :default
+
+  # Will render app/views/spree/solidus_content/info.html.erb
+  get "privacy", to: 'solidus_content#show', type: :info, id: :privacy
+  get "legal", to: 'solidus_content#show', type: :info, id: :legal
+
+  # Will render app/views/spree/solidus_content/info.html.erb
+  get "blog/:id", to: 'solidus_content#show', type: :post
+end
 ```
 
 Configuration
@@ -53,6 +90,10 @@ Configure SolidusContent in an initializer:
 
 SolidusContent.configure do |config|
   # your configuration goes here...
+
+  # Set to `true` to register your own route, instead of using the default
+  # that starts with `/c/`.
+  # config.skip_default_route = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,29 @@ bundle exec rails g solidus_content:install
 Usage
 -----
 
+Create an entry type for the home page:
+
 ```rb
 home_entry_type = SolidusContent::EntryType.create!(
   name: :home,
   content_provider_name: :json,
-  options: { path: 'app/content/home' }
+  options: { path: 'data/home' }
 )
+```
 
+Create a default entry for the home page:
+
+```rb
 home = SolidusContent.create!(
   content_type: home_entry_type,
   slug: :default,
 )
+```
+
+And then write a file inside your app root under `data/home/default.json`:
+
+```json
+{"title":"Hello World!"}
 ```
 
 ### Within an existing view

--- a/app/controllers/spree/solidus_content_controller.rb
+++ b/app/controllers/spree/solidus_content_controller.rb
@@ -1,0 +1,12 @@
+# require 'solidus_content/engine'
+require_dependency 'solidus_content/entry_type'
+
+class Spree::SolidusContentController < Spree::StoreController
+  def show
+    @entry_type = ::SolidusContent::EntryType.find_by!(name: params[:type])
+    @entry = @entry_type.entries.find_by!(slug: params[:id] || :default)
+    @data = @entry.data
+    
+    render action: @entry_type.name
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  unless SolidusContent.config.skip_default_route
+    get '/c/:type(/:id)', to: 'solidus_content#show', id: :default, as: :solidus_content
+  end
 end

--- a/lib/solidus_content/configuration.rb
+++ b/lib/solidus_content/configuration.rb
@@ -13,4 +13,8 @@ class SolidusContent::Configuration
       raise UnknownProvider, "Can't find a provider for #{key.inspect}"
     end
   end
+
+  # Set to true to prevent SolidusContent from adding the default route.
+  # See also the README and config/routes.rb.
+  attr_accessor :skip_default_route
 end

--- a/spec/features/render_content_with_views_spec.rb
+++ b/spec/features/render_content_with_views_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+feature 'Render content with views' do
+  let(:post) { create(:entry_type, name: :post, content_provider_name: :raw) }
+  let(:view_path) { Rails.root.join('app/views/spree/solidus_content/post.html.erb') }
+  
+  let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}
+  let!(:post_two) { create(:entry, slug: 'two', options: {title: "second post"}, entry_type: post)}
+
+  before { view_path.dirname.mkpath }
+  after { view_path.delete }
+
+  background { view_path.write(%{<main><h1><%= @data[:title] %></h1></main>}) }
+
+  scenario 'rendering posts as views' do
+    visit '/c/post/one'
+    expect(page.find(:css, 'main h1')).to have_content 'first post'
+    visit '/c/post/two'
+    expect(page.find(:css, 'main h1')).to have_content 'second post'
+  end
+
+  context "when the default route is disabled" do
+    scenario "it gives 404 when the default route is disabled" do
+      SolidusContent.config.skip_default_route = true 
+      Rails.application.reload_routes!
+      expect {visit '/c/post/one'}.to raise_error(ActionController::RoutingError)
+
+      SolidusContent.config.skip_default_route = false
+      Rails.application.reload_routes!
+      expect {visit '/c/post/one'}.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
By default it renders under the `/c/ path`, similarly to what's done with taxons being rendered under `/t/…`.