### PR TITLE
Autoload providers instead of eager loading them at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ entry = SolidusContent::Entry.create!(
 )
 ```
 
+_Be sure to have added `gem "solidus_static_content"` to your Gemfile._
+
 ### Contentful
 
 To fetch the data we have to create a connection with Contentful passing the
@@ -225,6 +227,8 @@ entry = SolidusContent::Entry.create!(
   options: { entry_id: 'XXX' }
 )
 ```
+
+_Be sure to have added `gem "contentful"` to your Gemfile._
 
 ### Prismic
 
@@ -251,6 +255,8 @@ entry = SolidusContent::Entry.create!(
   options: { id: 'XXX' }
 )
 ```
+
+_Be sure to have added `gem "prismic.io"` to your Gemfile._
 
 Registering a content provider
 ==============================

--- a/app/models/solidus_content/content_providers.rb
+++ b/app/models/solidus_content/content_providers.rb
@@ -1,3 +1,0 @@
-# Just a namespace for content-providers
-module SolidusContent::ContentProviders
-end

--- a/lib/solidus_content.rb
+++ b/lib/solidus_content.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/dependencies/autoload"
+
 require 'solidus_core'
 require 'solidus_support'
 
@@ -24,12 +26,13 @@ module SolidusContent
 
   # This module will be the namespace for default providers
   module ContentProviders
+    extend ActiveSupport::Autoload
+
+    autoload :JSON
+    autoload :RAW
+    autoload :YAML
+    autoload :Contentful
+    autoload :Prismic
+    autoload :SolidusStaticContent
   end
 end
-
-require 'solidus_content/content_providers/json'
-require 'solidus_content/content_providers/raw'
-require 'solidus_content/content_providers/yaml'
-require 'solidus_content/content_providers/contentful'
-require 'solidus_content/content_providers/prismic'
-require 'solidus_content/content_providers/solidus_static_content'

--- a/lib/solidus_content/configuration.rb
+++ b/lib/solidus_content/configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spree/core/class_constantizer'
+require 'active_support/core_ext/string/inflections'
 
 class SolidusContent::Configuration
   UnknownProvider = Class.new(StandardError)
@@ -9,8 +10,16 @@ class SolidusContent::Configuration
   # values. Each content-provider will be called passing the `entry_options:` 
   # and `entry_type_options:`. 
   def content_providers
-    @content_providers ||= Hash.new do |_hash, key|
-      raise UnknownProvider, "Can't find a provider for #{key.inspect}"
+    @content_providers ||= Hash.new do |hash, key|
+      provider = SolidusContent::ContentProviders.constants.find do |constant|
+        constant.to_s.underscore == key.to_s
+      end
+
+      if provider
+        hash[key.to_sym] = SolidusContent::ContentProviders.const_get(provider)
+      else
+        raise UnknownProvider, "Can't find a provider for #{key.inspect}"
+      end
     end
   end
 

--- a/lib/solidus_content/content_providers/contentful.rb
+++ b/lib/solidus_content/content_providers/contentful.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'contentful'
+
 module SolidusContent::ContentProviders::Contentful
   def self.call(input)
     type_options = input.dig(:type_options)

--- a/lib/solidus_content/content_providers/contentful.rb
+++ b/lib/solidus_content/content_providers/contentful.rb
@@ -16,6 +16,4 @@ module SolidusContent::ContentProviders::Contentful
       provider_entry: entry,
     )
   end
-
-  SolidusContent.config.content_providers[:contentful] = self
 end

--- a/lib/solidus_content/content_providers/contentful.rb
+++ b/lib/solidus_content/content_providers/contentful.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusContent::ContentProviders::Contentful
   def self.call(input)
     type_options = input.dig(:type_options)

--- a/lib/solidus_content/content_providers/json.rb
+++ b/lib/solidus_content/content_providers/json.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module SolidusContent::ContentProviders::JSON
   def self.call(input)
     dir = Rails.root.join(input.dig(:type_options, :path))

--- a/lib/solidus_content/content_providers/json.rb
+++ b/lib/solidus_content/content_providers/json.rb
@@ -6,6 +6,4 @@ module SolidusContent::ContentProviders::JSON
   
     input.merge(data: data)
   end
-
-  SolidusContent.config.content_providers[:json] = self
 end

--- a/lib/solidus_content/content_providers/json.rb
+++ b/lib/solidus_content/content_providers/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusContent::ContentProviders::JSON
   def self.call(input)
     dir = Rails.root.join(input.dig(:type_options, :path))

--- a/lib/solidus_content/content_providers/prismic.rb
+++ b/lib/solidus_content/content_providers/prismic.rb
@@ -18,6 +18,4 @@ module SolidusContent::ContentProviders::Prismic
       provider_entry: entry,
     )
   end
-
-  SolidusContent.config.content_providers[:prismic] = self
 end

--- a/lib/solidus_content/content_providers/prismic.rb
+++ b/lib/solidus_content/content_providers/prismic.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'prismic'
+
 module SolidusContent::ContentProviders::Prismic
   def self.call(input)
     type_options = input.dig(:type_options)

--- a/lib/solidus_content/content_providers/raw.rb
+++ b/lib/solidus_content/content_providers/raw.rb
@@ -3,6 +3,4 @@ module SolidusContent::ContentProviders::RAW
   def self.call(input)
     input.merge(data: input[:options])
   end
-
-  SolidusContent.config.content_providers[:raw] = self
 end

--- a/lib/solidus_content/content_providers/raw.rb
+++ b/lib/solidus_content/content_providers/raw.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Let the content come from the entry itself.
 module SolidusContent::ContentProviders::RAW
   def self.call(input)

--- a/lib/solidus_content/content_providers/solidus_static_content.rb
+++ b/lib/solidus_content/content_providers/solidus_static_content.rb
@@ -6,6 +6,4 @@ module SolidusContent::ContentProviders::SolidusStaticContent
 
     input.merge(data: Spree::Page.find_by!(slug: slug).attributes.symbolize_keys)
   end
-
-  SolidusContent.config.content_providers[:solidus_static_content] = self
 end

--- a/lib/solidus_content/content_providers/yaml.rb
+++ b/lib/solidus_content/content_providers/yaml.rb
@@ -24,6 +24,4 @@ module SolidusContent::ContentProviders::YAML
       YAML.load(file.read, file.to_s, symbolize_names: true)
     end
   end
-
-  SolidusContent.config.content_providers[:yaml] = self
 end

--- a/lib/solidus_content/content_providers/yaml.rb
+++ b/lib/solidus_content/content_providers/yaml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'yaml'
 
 module SolidusContent::ContentProviders::YAML


### PR DESCRIPTION
Having a number of optional dependencies that are not included in the gemspec we should avoid eager loading providers that are unused.