### PR TITLE
Rename "content providers" to "providers"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pkg
 *.swp
 spec/dummy
 spec/examples.txt
+/sandbox

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ To register a content-provider, add a callable to the configuration under the
 name you prefer. The
 
 ```rb
-SolidusContent.config.register_content_providers :json, ->(input) {
+SolidusContent.config.register_provider :json, ->(input) {
   dir = Rails.root.join(input.dig(:type_options, :path))
   file = dir.join(input[:slug] + '.json')
   data = JSON.parse(file.read, symbolize_names: true)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Create an entry type for the home page:
 ```rb
 home_entry_type = SolidusContent::EntryType.create!(
   name: :home,
-  content_provider_name: :json,
+  provider_name: :json,
   options: { path: 'data/home' }
 )
 ```
@@ -117,7 +117,7 @@ options.
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'raw',
+  provider_name: 'raw',
 )
 entry = SolidusContent::Entry.create(
   slug: '2020-03-27-hello-world',
@@ -134,7 +134,7 @@ Will fetch the data from a JSON file within the directory specified by the
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'json',
+  provider_name: 'json',
   options: {path: 'data/posts'}
 )
 entry = SolidusContent::Entry.create(
@@ -160,7 +160,7 @@ If there isn't a file with the `yml` extension, the `yaml` extension will be tri
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'yaml',
+  provider_name: 'yaml',
   options: {path: 'data/posts'}
 )
 entry = SolidusContent::Entry.create(
@@ -186,7 +186,7 @@ If the page slug is the same of the entry one, we can avoid passing the options.
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'solidus_static_content'
+  provider_name: 'solidus_static_content'
 )
 
 entry = SolidusContent::Entry.create!(
@@ -208,7 +208,7 @@ Will fetch the data from Contentful passing the `entry_id` entry option.
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'contentful',
+  provider_name: 'contentful',
   options: {
     contentful_space_id: 'XXX',
     contentful_access_token: 'XXX'
@@ -236,7 +236,7 @@ Will fetch the data from Prismic passing the `id` entry option.
 ```rb
 posts = SolidusContent::EntryType.create(
   name: 'posts',
-  content_provider_name: 'prismic',
+  provider_name: 'prismic',
   options: {
     api_entry_point: 'XXX',
     api_token: 'XXX' # Only if the repository is private

--- a/app/models/solidus_content/entry_type.rb
+++ b/app/models/solidus_content/entry_type.rb
@@ -6,13 +6,13 @@ class SolidusContent::EntryType < ActiveRecord::Base
     content_provider.call(
       slug: entry.slug,
       type: name,
-      provider: content_provider_name,
+      provider: provider_name,
       options: entry.options.symbolize_keys,
       type_options: options.symbolize_keys,
     )
   end
 
   def content_provider
-    SolidusContent.config.content_providers[content_provider_name.to_sym]
+    SolidusContent.config.content_providers[provider_name.to_sym]
   end
 end

--- a/app/models/solidus_content/entry_type.rb
+++ b/app/models/solidus_content/entry_type.rb
@@ -3,7 +3,7 @@ class SolidusContent::EntryType < ActiveRecord::Base
   after_initialize { self.options ||= {} }
 
   def content_for(entry)
-    content_provider.call(
+    provider.call(
       slug: entry.slug,
       type: name,
       provider: provider_name,
@@ -12,7 +12,7 @@ class SolidusContent::EntryType < ActiveRecord::Base
     )
   end
 
-  def content_provider
-    SolidusContent.config.content_providers[provider_name.to_sym]
+  def provider
+    SolidusContent.config.providers[provider_name.to_sym]
   end
 end

--- a/db/migrate/20200306110114_create_solidus_content_entry_types.rb
+++ b/db/migrate/20200306110114_create_solidus_content_entry_types.rb
@@ -3,7 +3,7 @@ class CreateSolidusContentEntryTypes < ActiveRecord::Migration[5.0]
     create_table :solidus_content_entry_types do |t|
       t.string :name, null: false
       t.json :options, null: false
-      t.string :content_provider_name, null: false
+      t.string :provider_name, null: false
 
       t.timestamps
     end

--- a/lib/generators/solidus_content/install/templates/initializer.rb
+++ b/lib/generators/solidus_content/install/templates/initializer.rb
@@ -4,11 +4,11 @@ SolidusContent.configure do |config|
   # You can control the list of content providers that will be available to the 
   # backend.
   # 
-  # config.content_providers.delete :prismic
+  # config.providers.delete :prismic
 
   # Define a custom content provider.
   # 
-  # config.register_content_provider :data_dir, ->(input) {
+  # config.register_provider :data_dir, ->(input) {
   #   data = YAML.load(Rails.root.join('data', input[:slug] + '.yml').read)
   #   input.merge(data: data)
   # }

--- a/lib/solidus_content.rb
+++ b/lib/solidus_content.rb
@@ -29,10 +29,10 @@ module SolidusContent
   end
 
   # Register all the default providers
-  config.register_content_provider :json, :JSON
-  config.register_content_provider :raw, :RAW
-  config.register_content_provider :yaml, :YAML
-  config.register_content_provider :contentful, :Contentful
-  config.register_content_provider :prismic, :Prismic
-  config.register_content_provider :solidus_static_content, :SolidusStaticContent
+  config.register_provider :json, :JSON
+  config.register_provider :raw, :RAW
+  config.register_provider :yaml, :YAML
+  config.register_provider :contentful, :Contentful
+  config.register_provider :prismic, :Prismic
+  config.register_provider :solidus_static_content, :SolidusStaticContent
 end

--- a/lib/solidus_content.rb
+++ b/lib/solidus_content.rb
@@ -25,7 +25,7 @@ module SolidusContent
   end
 
   # This module will be the namespace for default providers
-  module ContentProviders
+  module Providers
   end
 
   # Register all the default providers

--- a/lib/solidus_content/configuration.rb
+++ b/lib/solidus_content/configuration.rb
@@ -8,8 +8,8 @@ class SolidusContent::Configuration
   # Register of content-providers, use symbols for keys and callables as
   # values. Each content-provider will be called passing the `entry_options:` 
   # and `entry_type_options:`. 
-  def content_providers
-    @content_providers ||= Hash.new do |hash, key|
+  def providers
+    @providers ||= Hash.new do |hash, key|
       raise UnknownProvider, "Can't find a provider for #{key.inspect}"
     end
   end
@@ -18,11 +18,11 @@ class SolidusContent::Configuration
   # See also the README and config/routes.rb.
   attr_accessor :skip_default_route
 
-  def register_content_provider(name, provider)
+  def register_provider(name, provider)
     if provider.is_a? Symbol
-      require "solidus_content/content_providers/#{provider.to_s.underscore}"
+      require "solidus_content/providers/#{provider.to_s.underscore}"
       provider = SolidusContent::Providers.const_get(provider)
     end
-    content_providers[name.to_sym] = provider
+    providers[name.to_sym] = provider
   end
 end

--- a/lib/solidus_content/configuration.rb
+++ b/lib/solidus_content/configuration.rb
@@ -21,7 +21,7 @@ class SolidusContent::Configuration
   def register_content_provider(name, provider)
     if provider.is_a? Symbol
       require "solidus_content/content_providers/#{provider.to_s.underscore}"
-      provider = SolidusContent::ContentProviders.const_get(provider)
+      provider = SolidusContent::Providers.const_get(provider)
     end
     content_providers[name.to_sym] = provider
   end

--- a/lib/solidus_content/providers/contentful.rb
+++ b/lib/solidus_content/providers/contentful.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusContent::ContentProviders::Contentful
+module SolidusContent::Providers::Contentful
   def self.call(input)
     require 'contentful' unless defined?(::Contentful)
 

--- a/lib/solidus_content/providers/json.rb
+++ b/lib/solidus_content/providers/json.rb
@@ -2,7 +2,7 @@
 
 require 'json'
 
-module SolidusContent::ContentProviders::JSON
+module SolidusContent::Providers::JSON
   def self.call(input)
     dir = Rails.root.join(input.dig(:type_options, :path))
     file = dir.join(input[:slug] + '.json')

--- a/lib/solidus_content/providers/prismic.rb
+++ b/lib/solidus_content/providers/prismic.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusContent::ContentProviders::Prismic
+module SolidusContent::Providers::Prismic
   def self.call(input)
     require 'prismic' unless defined?(::Prismic)
     

--- a/lib/solidus_content/providers/raw.rb
+++ b/lib/solidus_content/providers/raw.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Let the content come from the entry itself.
-module SolidusContent::ContentProviders::RAW
+module SolidusContent::Providers::RAW
   def self.call(input)
     input.merge(data: input[:options])
   end

--- a/lib/solidus_content/providers/solidus_static_content.rb
+++ b/lib/solidus_content/providers/solidus_static_content.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module SolidusContent::ContentProviders::SolidusStaticContent
+module SolidusContent::Providers::SolidusStaticContent
   def self.call(input)
     slug = input.dig(:options, :slug) || input[:slug]
 

--- a/lib/solidus_content/providers/yaml.rb
+++ b/lib/solidus_content/providers/yaml.rb
@@ -2,7 +2,7 @@
 
 require 'yaml'
 
-module SolidusContent::ContentProviders::YAML
+module SolidusContent::Providers::YAML
   def self.call(input)
     dir = Rails.root.join(input.dig(:type_options, :path))
     file = dir.join(input[:slug] + '.yml')

--- a/spec/features/render_content_with_views_spec.rb
+++ b/spec/features/render_content_with_views_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 feature 'Render content with views' do
-  let(:post) { create(:entry_type, name: :post, content_provider_name: :raw) }
+  let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
   let(:view_path) { Rails.root.join('app/views/spree/solidus_content/post.html.erb') }
   
   let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}

--- a/spec/models/solidus_content/entry_type_spec.rb
+++ b/spec/models/solidus_content/entry_type_spec.rb
@@ -10,17 +10,17 @@ RSpec.describe SolidusContent::EntryType do
   describe '#content_for' do
     let(:entry_options) { {} }
     let(:entry_type_options) { {} }
-    let(:entry_type) { create(:entry_type, content_provider_name: content_provider_name) }
+    let(:entry_type) { create(:entry_type, provider_name: provider_name) }
     let(:entry) { create(:entry, slug: :example, entry_type: entry_type, options: entry_options) }
 
     shared_examples :content_provider do
       it 'calls the content-provider call method' do
         expect(
-          SolidusContent.config.content_providers[content_provider_name.to_sym]
+          SolidusContent.config.content_providers[provider_name.to_sym]
         ).to receive(:call).with(
           slug: entry.slug,
           type: entry_type.name,
-          provider: content_provider_name,
+          provider: provider_name,
           options: entry.options.symbolize_keys,
           type_options: entry_type.options.symbolize_keys,
         ).and_return(content)
@@ -30,7 +30,7 @@ RSpec.describe SolidusContent::EntryType do
     end
 
     context 'with the JSON provider' do
-      let(:content_provider_name) { 'json' }
+      let(:provider_name) { 'json' }
       let(:entry_type_options) { {path: "#{FIXTURES_PATH}/content"} }
       let(:content) { {foo: "bar"} }
 
@@ -38,7 +38,7 @@ RSpec.describe SolidusContent::EntryType do
     end
 
     context 'with the RAW provider' do
-      let(:content_provider_name) { 'raw' }
+      let(:provider_name) { 'raw' }
       let(:entry_options) { {foo: "bar"} }
       let(:content) { {foo: "bar"} }
 
@@ -46,21 +46,21 @@ RSpec.describe SolidusContent::EntryType do
     end
 
     context 'with the solidus static content provider' do
-      let(:content_provider_name) { 'solidus_static_content' }
+      let(:provider_name) { 'solidus_static_content' }
       let(:content) { { foo: 'bar' } }
 
       it_behaves_like :content_provider
     end
 
     context 'with the Prismic provider' do
-      let(:content_provider_name) { 'prismic' }
+      let(:provider_name) { 'prismic' }
       let(:content) { { foo: 'bar' } }
 
       it_behaves_like :content_provider
     end
 
     context 'with an unknown provider' do
-      let(:content_provider_name) { 'unknown' }
+      let(:provider_name) { 'unknown' }
 
       it 'raises an unknow provider error' do
         expect { entry_type.content_for(entry_options) }

--- a/spec/models/solidus_content/entry_type_spec.rb
+++ b/spec/models/solidus_content/entry_type_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe SolidusContent::EntryType do
     let(:entry_type) { create(:entry_type, provider_name: provider_name) }
     let(:entry) { create(:entry, slug: :example, entry_type: entry_type, options: entry_options) }
 
-    shared_examples :content_provider do
+    shared_examples :provider do
       it 'calls the content-provider call method' do
         expect(
-          SolidusContent.config.content_providers[provider_name.to_sym]
+          SolidusContent.config.providers[provider_name.to_sym]
         ).to receive(:call).with(
           slug: entry.slug,
           type: entry_type.name,
@@ -34,7 +34,7 @@ RSpec.describe SolidusContent::EntryType do
       let(:entry_type_options) { {path: "#{FIXTURES_PATH}/content"} }
       let(:content) { {foo: "bar"} }
 
-      it_behaves_like :content_provider
+      it_behaves_like :provider
     end
 
     context 'with the RAW provider' do
@@ -42,21 +42,21 @@ RSpec.describe SolidusContent::EntryType do
       let(:entry_options) { {foo: "bar"} }
       let(:content) { {foo: "bar"} }
 
-      it_behaves_like :content_provider
+      it_behaves_like :provider
     end
 
     context 'with the solidus static content provider' do
       let(:provider_name) { 'solidus_static_content' }
       let(:content) { { foo: 'bar' } }
 
-      it_behaves_like :content_provider
+      it_behaves_like :provider
     end
 
     context 'with the Prismic provider' do
       let(:provider_name) { 'prismic' }
       let(:content) { { foo: 'bar' } }
 
-      it_behaves_like :content_provider
+      it_behaves_like :provider
     end
 
     context 'with an unknown provider' do

--- a/spec/solidus_content/configuration_spec.rb
+++ b/spec/solidus_content/configuration_spec.rb
@@ -5,26 +5,26 @@ require 'spec_helper'
 RSpec.describe SolidusContent::Configuration do
   subject(:configuration) { described_class.new }
 
-  describe '#content_providers' do
+  describe '#providers' do
     context 'without a configuration' do
       it 'is an empty hash' do
-        expect(configuration.content_providers).to eq(Hash.new)
+        expect(configuration.providers).to eq(Hash.new)
       end
     end
 
     context 'with a configuration' do
-      let(:foo_content_provider) { double(:foo_content_provider) }
-      before { configuration.content_providers[:foo] = foo_content_provider }
+      let(:foo_provider) { double(:foo_provider) }
+      before { configuration.providers[:foo] = foo_provider }
 
       context 'asking for an existing configuration' do
         it 'returns the configuration' do
-          expect(configuration.content_providers[:foo]).to eq(foo_content_provider)
+          expect(configuration.providers[:foo]).to eq(foo_provider)
         end
       end
 
       context 'asking for a not existing configuration' do
         it 'returns the configuration' do
-          expect { configuration.content_providers[:bar] }
+          expect { configuration.providers[:bar] }
             .to raise_error(
               SolidusContent::Configuration::UnknownProvider,
               "Can't find a provider for :bar"

--- a/spec/solidus_content/providers/contentful_spec.rb
+++ b/spec/solidus_content/providers/contentful_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SolidusContent::ContentProviders::Contentful do
+RSpec.describe SolidusContent::Providers::Contentful do
   describe '.call' do
     subject do
       described_class.call(

--- a/spec/solidus_content/providers/json_spec.rb
+++ b/spec/solidus_content/providers/json_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SolidusContent::ContentProviders::JSON do
+RSpec.describe SolidusContent::Providers::JSON do
   context "with an absolute path" do
     let(:path) { File.absolute_path('content', FIXTURE_PATH) }
 

--- a/spec/solidus_content/providers/prismic_spec.rb
+++ b/spec/solidus_content/providers/prismic_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SolidusContent::ContentProviders::Prismic do
+RSpec.describe SolidusContent::Providers::Prismic do
   describe '.call' do
     subject do
       described_class.call(

--- a/spec/solidus_content/providers/solidus_static_content_spec.rb
+++ b/spec/solidus_content/providers/solidus_static_content_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SolidusContent::ContentProviders::SolidusStaticContent do
+RSpec.describe SolidusContent::Providers::SolidusStaticContent do
   let(:page) { create(:page) }
 
   context 'passing the slug in the options' do

--- a/spec/solidus_content/providers/yaml_spec.rb
+++ b/spec/solidus_content/providers/yaml_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe SolidusContent::ContentProviders::YAML do
+RSpec.describe SolidusContent::Providers::YAML do
   let(:path) { File.absolute_path('content', FIXTURE_PATH) }
 
   context "when the yml extension isn't available" do


### PR DESCRIPTION
After some pondering I came to the conclusion that "provider" was already in the context of "content" and that the repetition was redundant.