### PR TITLE
Allow solidus support 0.5

### DIFF
--- a/.rufo
+++ b/.rufo
@@ -1,0 +1,1 @@
+quote_style :single

--- a/solidus_content.gemspec
+++ b/solidus_content.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.files = files.grep_v(%r{^(test|spec|features)/})
   spec.test_files = files.grep(%r{^(test|spec|features)/})
-  spec.bindir = "exe"
+  spec.bindir = 'exe'
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.4.0'

--- a/solidus_content.gemspec
+++ b/solidus_content.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.4.0'
+  spec.add_dependency 'solidus_support', '~> 0.4'
 
   spec.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
`solidus_static_content` uses `solidus_support` 0.5, we should allow this as well, otherwise we cannot install anything without getting an bundle error.

Also adds a `.rufo` config file for telling Rufo (the automatic Ruby formatter) to use single quotes. This helps people that have a code formatter installed - like me - to contribute and still follow the current syntax style.