### PR TITLE
Add AlchemyCMS content provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .sass-cache
 coverage
 Gemfile.lock
+Gemfile-local
 tmp
 nbproject
 pkg

--- a/.rufo
+++ b/.rufo
@@ -1,0 +1,1 @@
+quote_style :single

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 gem 'contentful'
 gem 'prismic.io', require: 'prismic'
 gem 'solidus_static_content', github: 'solidusio-contrib/solidus_static_content'
+gem 'alchemy_cms', github: 'AlchemyCMS/alchemy_cms'
 
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ E.g. `app/views/spree/solidus_content/home.html.erb`:
 <h1><%= data[:title] %></h1>
 ```
 
-Then, visit `/c/home/default` or even just `/c/home` (when the content slug is 
+Then, visit `/c/home/default` or even just `/c/home` (when the content slug is
 "default" it can be omitted).
 
 
 ### With a custom route
 
-You can also define a custom route and use the SolidusContent controller to 
+You can also define a custom route and use the SolidusContent controller to
 render your content from a dedicated view:
 
 ```rb
@@ -251,6 +251,29 @@ entry = SolidusContent::Entry.create!(
 ```
 
 _Be sure to have added `gem "prismic.io"` to your Gemfile._
+
+### AlchemyCMS
+
+Will fetch the data from an [AlchemyCMS](https://github.com/AlchemyCMS/alchemy_cms) page passing the `slug` entry option.
+
+You can also filter the elements to include with the page by passing `only` and `except` with the `options` hash. _Note: It will return all elements from that page if omitted._
+
+All element finder options are supported. Please have a look into [its documentation](https://github.com/AlchemyCMS/alchemy_cms/blob/master/lib/alchemy/elements_finder.rb) for available options.
+
+```rb
+pages = SolidusContent::EntryType.create(
+  name: 'pages',
+  provider_name: 'alchemy'
+)
+
+entry = SolidusContent::Entry.create!(
+  slug: 'hello/world',
+  entry_type: pages,
+  options: { only: 'article' }
+)
+```
+
+_Be sure to have `gem "alchemy_cms"` added to your `Gemfile`._
 
 Registering a content provider
 ==============================

--- a/config/initializers/alchemy.rb
+++ b/config/initializers/alchemy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+if defined?(::Alchemy)
+  Alchemy.user_class_name = 'Spree::User'
+  Alchemy.current_user_method = :spree_current_user
+end

--- a/lib/solidus_content.rb
+++ b/lib/solidus_content.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "active_support/dependencies/autoload"
+require 'active_support/dependencies/autoload'
 
 require 'solidus_core'
 require 'solidus_support'
@@ -35,4 +35,5 @@ module SolidusContent
   config.register_provider :contentful, :Contentful
   config.register_provider :prismic, :Prismic
   config.register_provider :solidus_static_content, :SolidusStaticContent
+  config.register_provider :alchemy, :Alchemy
 end

--- a/lib/solidus_content/providers/alchemy.rb
+++ b/lib/solidus_content/providers/alchemy.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module SolidusContent::Providers::Alchemy
+  class << self
+    #
+    # Load content from an AlchemyCMS page
+    #
+    # @param [Hash] input Hash with options.
+    #
+    # input[:slug] [String] :only A page urlname
+    #
+    # You can pass options to the element finder as well
+    #
+    # input[:options] [Array<String>|String] :only A list of element names to load only.
+    # input[:options] [Array<String>|String] :except A list of element names not to load.
+    # input[:options] [Boolean] :fixed (false) Return only fixed elements
+    # input[:options] [Integer] :count The amount of elements to load
+    # input[:options] [Integer] :offset The offset to begin loading elements from
+    #
+    # @return [<Hash>] Hash with :data holding the page attributes and elements from that page
+    #
+    def call(input)
+      require 'alchemy_cms' unless defined?(::Alchemy)
+
+      page = pages(input).first ||
+             raise(
+               ActiveRecord::RecordNotFound,
+               "Page with urlname #{input[:slug]} not found!"
+             )
+
+      input.merge(
+        data: page.attributes.symbolize_keys.merge(
+          elements: elements_finder(input[:options]).elements(page: page),
+        ),
+      )
+    end
+
+    private
+
+    def pages(input)
+      Alchemy::Page.where(urlname: input.fetch(:slug)).includes(*page_includes)
+    end
+
+    def page_includes
+      [
+        :tags,
+        {
+          all_elements: [
+            {
+              contents: {
+                essence: :ingredient_association,
+              },
+            },
+            :tags,
+          ],
+        },
+      ]
+    end
+
+    def elements_finder(options)
+      Alchemy::ElementsFinder.new(options || {})
+    end
+  end
+end

--- a/solidus_content.gemspec
+++ b/solidus_content.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
 
   spec.files = files.grep_v(%r{^(test|spec|features)/})
   spec.test_files = files.grep(%r{^(test|spec|features)/})
-  spec.bindir = "exe"
+  spec.bindir = 'exe'
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.4.0'

--- a/solidus_content.gemspec
+++ b/solidus_content.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
-  spec.add_dependency 'solidus_support', '~> 0.4.0'
+  spec.add_dependency 'solidus_support', '~> 0.4'
 
   spec.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/solidus_content/providers/alchemy_spec.rb
+++ b/spec/solidus_content/providers/alchemy_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'generators/alchemy/install/install_generator'
+require 'alchemy/test_support/factories/element_factory'
+
+RSpec.describe SolidusContent::Providers::Alchemy do
+  let!(:element) { create(:alchemy_element, page: page) }
+  let(:page) { create(:alchemy_page) }
+
+  before(:all) do
+    Alchemy::Generators::InstallGenerator.start(['--skip-demo-files', '--skip', '--quiet'])
+  end
+
+  context 'passing the slug in the options' do
+    context 'for an existing page' do
+      it 'returns page attributes plus elements' do
+        expect(
+          described_class.call(slug: page.urlname)[:data]
+        ).to eq(page.attributes.symbolize_keys.merge(elements: page.elements))
+      end
+
+      context 'and passing element names in the options' do
+        let!(:header) { create(:alchemy_element, name: 'header', page: page) }
+
+        it 'returns only elements having that name' do
+          expect(
+            described_class.call(slug: page.urlname, options: { only: 'header' })[:data][:elements]
+          ).to eq(page.elements.named('header'))
+        end
+      end
+
+      context 'and passing element names in the options to exclude' do
+        let!(:header) { create(:alchemy_element, name: 'header', page: page) }
+
+        it 'returns only elements having that name' do
+          expect(
+            described_class.call(slug: page.urlname, options: { except: 'header' })[:data][:elements]
+          ).to eq(page.elements.named('article'))
+        end
+      end
+    end
+
+    context 'for an unknown page' do
+      it 'raises not found error' do
+        expect {
+          described_class.call(slug: 'not/known')
+        }.to raise_error('Page with urlname not/known not found!')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Builds on top of #18 

This allows to load content from an Alchemy page. It also allows to filter the elements to include with the page, making it possible to only load a specific element from a page.

Make sure to have `gem 'alchemy_cms'` added to your `Gemfile`.

It was necessary to include an inititalizer and test setup code. I tried my best to make it as unobtrusive as possible.

_Disclaimer: I might not have completed understand the `Entry` and `EntryType` records and how to correctly use them in the context of an Alchemy page. Maybe it makes sense to walk me through this and how those records are meant._