### PR TITLE
Fix Entry creation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ home_entry_type = SolidusContent::EntryType.create!(
 Create a default entry for the home page:
 
 ```rb
-home = SolidusContent.create!(
-  content_type: home_entry_type,
+home = SolidusContent::Entry.create!(
+  entry_type: home_entry_type,
   slug: :default,
 )
 ```


### PR DESCRIPTION
To create an `Entry` we have call create on the `Entry` and `content_type` does not exist anymore, updated this to the proper `entry_type` attribute.

The rest of the README is a bit behind as well, the `data_for` method is not present. I would love to update the README with the proper interface, but not sure what that currently is.

To render data we have to get an `Entry` instance and call `data` or `content` on that instance. 

The `data_for` method looks nice though, pass in the type and slug and get data. What is the bigger picture here? Should we mark this as WIP in the README?

I'm implementing this currently and I have so many questions :) (and opinions ;) ). 