### PR TITLE
Remove deprecated Decorators include

### DIFF
--- a/lib/solidus_content/engine.rb
+++ b/lib/solidus_content/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusContent
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 


### PR DESCRIPTION
Fixes 
```
DEPRECATION WARNING: SolidusSupport::EngineExtensions::Decorators is deprecated! Use SolidusSupport::EngineExtensions instead.
```