### PR TITLE
Add Entry.data_for(type, slug)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ And then write a file inside your app root under `data/home/default.json`:
 Use the content inside an existing view, e.g. `app/views/spree/home/index.html.erb`:
 
 ```erb
-<% data = SolidusContent::EntryType.find_by(name: 'home').entries.find_by(slug: 'default').data %>
+<% data = SolidusContent::Entry.data_for(:home, 'default') %>
 
 <h1><%= data[:title] %></h1>
 ```
@@ -267,7 +267,7 @@ Renderful instance:
 
 ```ruby
 # [RAILS_ROOT]/config/initializers/solidus_content.rb
- 
+
 require 'solidus_content/providers/renderful'
 
 renderful = Renderful::Client.new(...)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ be able to render your content.
 
 E.g. `app/views/spree/solidus_content/home.html.erb`:
 ```erb
-<h1><%= @data[:title] %></h1>
+<h1><%= @entry.data[:title] %></h1>
 ```
 
 Then, visit `/c/home/default` or even just `/c/home` (when the content slug is
@@ -298,7 +298,7 @@ Instead, you will get a `:render_in` proc that you should call with your view co
 will be forwarded to Renderful, which will render your content:
 
 ```erb
-<%= @data[:render_in].(self) %>
+<%= @entry.data[:render_in].(self) %>
 ```
 
 Registering a content provider

--- a/app/controllers/spree/solidus_content_controller.rb
+++ b/app/controllers/spree/solidus_content_controller.rb
@@ -5,7 +5,7 @@ class Spree::SolidusContentController < Spree::StoreController
     slug = params[:id] || :default
     entry_type_name = params[:type]
 
-    @entry = ::SolidusContent::Entry.get(entry_type_name, slug)
+    @entry = ::SolidusContent::Entry.by_type(entry_type_name).by_slug(slug)
     render action: entry_type_name
   end
 end

--- a/app/controllers/spree/solidus_content_controller.rb
+++ b/app/controllers/spree/solidus_content_controller.rb
@@ -1,12 +1,11 @@
-# require 'solidus_content/engine'
 require_dependency 'solidus_content/entry_type'
 
 class Spree::SolidusContentController < Spree::StoreController
   def show
-    @entry_type = ::SolidusContent::EntryType.find_by!(name: params[:type])
-    @entry = @entry_type.entries.find_by!(slug: params[:id] || :default)
-    @data = @entry.data
-    
-    render action: @entry_type.name
+    slug = params[:id] || :default
+    entry_type_name = params[:type]
+
+    @entry = ::SolidusContent::Entry.get(entry_type_name, slug)
+    render action: entry_type_name
   end
 end

--- a/app/models/solidus_content/entry.rb
+++ b/app/models/solidus_content/entry.rb
@@ -6,12 +6,15 @@ class SolidusContent::Entry < ActiveRecord::Base
 
   scope :by_slug, ->(slug) { find_by!(slug: slug) }
 
-  def self.data_for(entry_type_name, slug)
-    get(entry_type_name, slug).data
+  def self.data_for(type, slug)
+    by_type(type).by_slug(slug).data
   end
 
-  def self.get(entry_type_name, slug)
-    SolidusContent::EntryType.by_type_name(entry_type_name).entries.by_slug(slug)
+  def self.by_type(type)
+    unless type.is_a? SolidusContent::EntryType
+      type = SolidusContent::EntryType.by_name(type)
+    end
+    where(entry_type: type)
   end
 
   def data

--- a/app/models/solidus_content/entry.rb
+++ b/app/models/solidus_content/entry.rb
@@ -6,8 +6,12 @@ class SolidusContent::Entry < ActiveRecord::Base
 
   scope :by_slug, ->(slug) { find_by!(slug: slug) }
 
-  def self.data_for(entry_type, slug)
-    SolidusContent::EntryType.find_by!(name: entry_type).entries.by_slug(slug).data
+  def self.data_for(entry_type_name, slug)
+    get(entry_type_name, slug).data
+  end
+
+  def self.get(entry_type_name, slug)
+    SolidusContent::EntryType.by_type_name(entry_type_name).entries.by_slug(slug)
   end
 
   def data

--- a/app/models/solidus_content/entry.rb
+++ b/app/models/solidus_content/entry.rb
@@ -4,10 +4,10 @@ class SolidusContent::Entry < ActiveRecord::Base
   belongs_to :entry_type
   after_initialize { self.options ||= {} }
 
-  scope :by_slug, ->(slug) { where(slug: slug).take }
+  scope :by_slug, ->(slug) { find_by!(slug: slug) }
 
   def self.data_for(entry_type, slug)
-    SolidusContent::EntryType.find_by(name: entry_type).entries.by_slug(slug).data
+    SolidusContent::EntryType.find_by!(name: entry_type).entries.by_slug(slug).data
   end
 
   def data

--- a/app/models/solidus_content/entry.rb
+++ b/app/models/solidus_content/entry.rb
@@ -4,6 +4,12 @@ class SolidusContent::Entry < ActiveRecord::Base
   belongs_to :entry_type
   after_initialize { self.options ||= {} }
 
+  scope :by_slug, ->(slug) { where(slug: slug).take }
+
+  def self.data_for(entry_type, slug)
+    SolidusContent::EntryType.find_by(name: entry_type).entries.by_slug(slug).data
+  end
+
   def data
     content[:data]
   end

--- a/app/models/solidus_content/entry_type.rb
+++ b/app/models/solidus_content/entry_type.rb
@@ -2,6 +2,8 @@ class SolidusContent::EntryType < ActiveRecord::Base
   has_many :entries
   after_initialize { self.options ||= {} }
 
+  scope :by_type_name, ->(type_name) { find_by!(name: type_name) }
+
   validates :name, :provider_name, presence: true
 
   def content_for(entry)

--- a/app/models/solidus_content/entry_type.rb
+++ b/app/models/solidus_content/entry_type.rb
@@ -2,6 +2,8 @@ class SolidusContent::EntryType < ActiveRecord::Base
   has_many :entries
   after_initialize { self.options ||= {} }
 
+  validates :name, :provider_name, presence: true
+
   def content_for(entry)
     provider.call(
       slug: entry.slug,

--- a/app/models/solidus_content/entry_type.rb
+++ b/app/models/solidus_content/entry_type.rb
@@ -2,7 +2,7 @@ class SolidusContent::EntryType < ActiveRecord::Base
   has_many :entries
   after_initialize { self.options ||= {} }
 
-  scope :by_type_name, ->(type_name) { find_by!(name: type_name) }
+  scope :by_name, ->(name) { find_by!(name: name) }
 
   validates :name, :provider_name, presence: true
 

--- a/lib/solidus_content/factories.rb
+++ b/lib/solidus_content/factories.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :entry_type, class: SolidusContent::EntryType do
     sequence(:name) { |n| "entry_type_#{n}" }
+    provider_name { :json }
   end
 
   factory :entry, class: SolidusContent::Entry do

--- a/spec/features/render_content_with_views_spec.rb
+++ b/spec/features/render_content_with_views_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 feature 'Render content with views' do
   let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
   let(:view_path) { Rails.root.join('app/views/spree/solidus_content/post.html.erb') }
-  
+
   let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}
   let!(:post_two) { create(:entry, slug: 'two', options: {title: "second post"}, entry_type: post)}
 
   before { view_path.dirname.mkpath }
   after { view_path.delete }
 
-  background { view_path.write(%{<main><h1><%= @data[:title] %></h1></main>}) }
+  background { view_path.write(%{<main><h1><%= @entry.data[:title] %></h1></main>}) }
 
   scenario 'rendering posts as views' do
     visit '/c/post/one'
@@ -21,7 +21,7 @@ feature 'Render content with views' do
 
   context "when the default route is disabled" do
     scenario "it gives 404 when the default route is disabled" do
-      SolidusContent.config.skip_default_route = true 
+      SolidusContent.config.skip_default_route = true
       Rails.application.reload_routes!
       expect {visit '/c/post/one'}.to raise_error(ActionController::RoutingError)
 

--- a/spec/models/solidus_content/entry_spec.rb
+++ b/spec/models/solidus_content/entry_spec.rb
@@ -13,10 +13,28 @@ RSpec.describe SolidusContent::Entry do
     let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
     let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}
 
-    it "returns data for type and slug" do
-      expect(
-        SolidusContent::Entry.data_for(:post, 'one')
-      ).to eq({title: "first post"})
+    context "with using correct type and slug" do
+      it "returns data" do
+        expect(
+          SolidusContent::Entry.data_for(:post, 'one')
+        ).to eq({title: "first post"})
+      end
+    end
+
+    context "with using invalid type" do
+      it "will raise an ActiveRecord::RecordNotFound exception" do
+        expect{
+          SolidusContent::Entry.data_for(:foo, 'one')
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with using an invalid slug" do
+      it "will raise an ActiveRecord::RecordNotFound exception" do
+        expect{
+          SolidusContent::Entry.data_for(:post, 'foo')
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 

--- a/spec/models/solidus_content/entry_spec.rb
+++ b/spec/models/solidus_content/entry_spec.rb
@@ -5,22 +5,32 @@ require "spec_helper"
 RSpec.describe SolidusContent::Entry do
   let(:entry) { build(:entry) }
 
+  let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
+  let(:home) { create(:entry_type, name: :home, provider_name: :raw) }
+
+  let!(:post_one) do
+    create(:entry,
+      slug: "one",
+      options: { title: "first post" },
+      entry_type: post
+    )
+  end
+
+  let!(:home_default) do
+    create(:entry,
+      slug: :default,
+      options: { title: "Homepage" },
+      entry_type: home
+    )
+  end
+
   it "has a valid factory" do
     expect(entry).to be_valid
   end
 
   describe ".data_for" do
-    let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
-    let!(:post_one) do
-      create(:entry,
-        slug: "one",
-        options: { title: "first post" },
-        entry_type: post
-      )
-    end
-
     context "with using correct type and slug" do
-      it "returns data" do
+      it "returns the stored data" do
         expect(
           SolidusContent::Entry.data_for(:post, "one")
         ).to eq({title: "first post"})
@@ -39,6 +49,32 @@ RSpec.describe SolidusContent::Entry do
       it "will raise an ActiveRecord::RecordNotFound exception" do
         expect{
           SolidusContent::Entry.data_for(:post, "foo")
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe ".by_type" do
+    context "with entry_type present" do
+      context "and symbol passed in for type" do
+        it "returns the correct Entries" do
+          expect(SolidusContent::Entry.by_type(:post)).to include post_one
+          expect(SolidusContent::Entry.by_type(:post)).to_not include home_default
+        end
+      end
+
+      context "and EntryType instance passed in for type" do
+        it "returns the correct Entries" do
+          expect(SolidusContent::Entry.by_type(post)).to include post_one
+          expect(SolidusContent::Entry.by_type(post)).to_not include home_default
+        end
+      end
+    end
+
+    context "with using invalid type" do
+      it "will raise an ActiveRecord::RecordNotFound exception" do
+        expect{
+          SolidusContent::Entry.by_type(:foo)
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/models/solidus_content/entry_spec.rb
+++ b/spec/models/solidus_content/entry_spec.rb
@@ -1,22 +1,28 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe SolidusContent::Entry do
   let(:entry) { build(:entry) }
 
-  it 'has a valid factory' do
+  it "has a valid factory" do
     expect(entry).to be_valid
   end
 
-  describe "#data_for" do
+  describe ".data_for" do
     let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
-    let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}
+    let!(:post_one) do
+      create(:entry,
+        slug: "one",
+        options: { title: "first post" },
+        entry_type: post
+      )
+    end
 
     context "with using correct type and slug" do
       it "returns data" do
         expect(
-          SolidusContent::Entry.data_for(:post, 'one')
+          SolidusContent::Entry.data_for(:post, "one")
         ).to eq({title: "first post"})
       end
     end
@@ -24,7 +30,7 @@ RSpec.describe SolidusContent::Entry do
     context "with using invalid type" do
       it "will raise an ActiveRecord::RecordNotFound exception" do
         expect{
-          SolidusContent::Entry.data_for(:foo, 'one')
+          SolidusContent::Entry.data_for(:foo, "one")
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -32,13 +38,13 @@ RSpec.describe SolidusContent::Entry do
     context "with using an invalid slug" do
       it "will raise an ActiveRecord::RecordNotFound exception" do
         expect{
-          SolidusContent::Entry.data_for(:post, 'foo')
+          SolidusContent::Entry.data_for(:post, "foo")
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
   end
 
-  specify '#data' do
+  specify "#data" do
     expect(entry.entry_type)
       .to receive(:content_for).with(entry).and_return({data: :foo})
 
@@ -46,7 +52,7 @@ RSpec.describe SolidusContent::Entry do
   end
 
   specify "#content" do
-    content = double('content')
+    content = double("content")
 
     expect(entry.entry_type)
       .to receive(:content_for).with(entry).and_return(content)

--- a/spec/models/solidus_content/entry_spec.rb
+++ b/spec/models/solidus_content/entry_spec.rb
@@ -9,10 +9,21 @@ RSpec.describe SolidusContent::Entry do
     expect(entry).to be_valid
   end
 
+  describe "#data_for" do
+    let(:post) { create(:entry_type, name: :post, provider_name: :raw) }
+    let!(:post_one) { create(:entry, slug: 'one', options: {title: "first post"}, entry_type: post)}
+
+    it "returns data for type and slug" do
+      expect(
+        SolidusContent::Entry.data_for(:post, 'one')
+      ).to eq({title: "first post"})
+    end
+  end
+
   specify '#data' do
     expect(entry.entry_type)
-      .to receive(:content_for).with(entry) .and_return({data: :foo})
-      
+      .to receive(:content_for).with(entry).and_return({data: :foo})
+
     expect(entry.data).to eq(:foo)
   end
 

--- a/spec/models/solidus_content/entry_type_spec.rb
+++ b/spec/models/solidus_content/entry_type_spec.rb
@@ -68,4 +68,22 @@ RSpec.describe SolidusContent::EntryType do
       end
     end
   end
+
+  describe '.by_name' do
+    let!(:home) { create(:entry_type, name: :home, provider_name: :raw) }
+
+    context "with existing name" do
+      it "returns the entry_type" do
+        expect(SolidusContent::EntryType.by_name(:home)).to eql home
+      end
+    end
+
+    context "with non-existing name" do
+      it "will raise an ActiveRecord::RecordNotFound exception" do
+        expect{
+          SolidusContent::EntryType.by_name(:post)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Introduces the `Entry.data_for` method. It takes a `EntryType` name and the `Entry` slug. 

- [x] Update README
- [x] Refactor to use this pattern in the controllers
- [x] Refactor to return an entry instance and not the data directly

Fixes #23 