### PR TITLE
Fix CircleCI badge in README after organisation switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # SolidusContent
 
-[![nebulab](https://circleci.com/gh/nebulab/solidus_content.svg?style=shield)](https://app.circleci.com/pipelines/github/nebulab/solidus_content)
+[![nebulab](https://circleci.com/gh/solidusio-contrib/solidus_content.svg?style=shield)](https://app.circleci.com/pipelines/github/nebulab/solidus_content)
 
 An extremely modular and extensible CMS for Solidus.
 


### PR DESCRIPTION
After the Github organisation switch, the badge URI needs to be updated to reflect the new location in CircleCI.