### PR TITLE
Remove Rails from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
-# Needed to help Bundler figure out how to resolve dependencies,
-# otherwise it takes forever to resolve them.
-# See https://github.com/bundler/bundler/issues/6677
-gem 'rails', '>0.a'
-
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,17 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
 gem 'solidus', github: 'solidusio/solidus', branch: branch
 
+# Needed to help Bundler figure out how to resolve dependencies,
+# otherwise it takes forever to resolve them.
+# See https://github.com/bundler/bundler/issues/6677
+if Gem::Version.new(Bundler::VERSION) < Gem::Version.new('2.1')
+  if branch == "master"
+    gem 'rails', '>0.a'
+  else
+    gem 'rails', '>0'
+  end
+end
+
 # Provides basic authentication functionality for testing parts of your engine
 gem 'solidus_auth_devise'
 


### PR DESCRIPTION
The bundler bug seems to be fixed and it is preventing us from locking the Rails version in the solidus `gemspec`. For example, Solidus 2.10 locks Rails to < 6.1 but this hack is making ignore that dependency lock.

EDIT: removing this, it takes forever to run builds on the CI. 