### PR TITLE
Fix bug with source_root in InstallGenerator

### DIFF
--- a/lib/generators/solidus_content/install/install_generator.rb
+++ b/lib/generators/solidus_content/install/install_generator.rb
@@ -3,6 +3,8 @@
 module SolidusContent
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path('templates', __dir__)
+
       class_option :auto_run_migrations, type: :boolean, default: false
 
       def add_javascripts


### PR DESCRIPTION
The InstallGenerator cannot find the templates directory because we
have not set the source_root. Doing so fixes the following error:

```
Could not find "initializer.rb" in any of your source paths. Please invoke SolidusContent::Generators::InstallGenerator.source_root(PATH) with the PATH containing your templates. Your current source paths are: 
/Users/madeline/supergood/solidus_content/vendor/bundle/ruby/2.6.0/bundler/gems/solidus-07bdb8d180d6/core/lib/generators/spree/dummy/templates
/Users/madeline/supergood/solidus_content/Users/madeline/supergood/solidus_content/vendor/bundle/ruby/2.6.0/bundler/gems/solidus-07bdb8d180d6/core/lib/generators/solidus/install/templates
/Users/madeline/supergood/solidus_content/spec/Users/madeline/supergood/solidus_content/vendor/bundle/ruby/2.6.0/bundler/gems/solidus-07bdb8d180d6/core/lib/generators/solidus/install/templates
/Users/madeline/supergood/solidus_content/vendor/bundle/ruby/2.6.0/bundler/gems/solidus-07bdb8d180d6/core/lib/generators/solidus/install/templates
```


This is also something that is recommended here: https://guides.rubyonrails.org/generators.html#creating-generators-with-generators