### PR TITLE
Allow Ruby 3

### DIFF
--- a/solidus_content.gemspec
+++ b/solidus_content.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/solidusio-contrib/solidus_content#readme'
   spec.metadata['changelog_uri'] = 'https://github.com/solidusio-contrib/solidus_content/releases'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This was blocking apps which use a newer release of Ruby from using this gem.